### PR TITLE
Let empty responses have HTTP No Content status

### DIFF
--- a/app/Http/Controllers/Orders/CheckoutController.php
+++ b/app/Http/Controllers/Orders/CheckoutController.php
@@ -8,8 +8,8 @@ use Domain\Orders\CheckoutOrder;
 use Domain\Orders\OrderDoesNotExist;
 use Domain\Orders\OrderId;
 use Domain\Orders\OrderIsAlreadyCheckedOut;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Validator;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
@@ -18,7 +18,7 @@ final class CheckoutController extends Controller
     public function __invoke(
         Request $request,
         string $orderIdString
-    ): JsonResponse {
+    ): Response {
         Validator::make(
             array_merge(
                 ['orderId' => $orderIdString],
@@ -42,6 +42,6 @@ final class CheckoutController extends Controller
             throw new BadRequestHttpException($exception->getMessage());
         }
 
-        return response()->json();
+        return response()->noContent();
     }
 }

--- a/app/Http/Controllers/Orders/RemoveLineItemController.php
+++ b/app/Http/Controllers/Orders/RemoveLineItemController.php
@@ -9,8 +9,8 @@ use Domain\Orders\OrderDoesNotExist;
 use Domain\Orders\OrderId;
 use Domain\Orders\OrderIsAlreadyCheckedOut;
 use Domain\Orders\RemoveLineItemFromOrder;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Validator;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
@@ -19,7 +19,7 @@ final class RemoveLineItemController extends Controller
     public function __invoke(
         Request $request,
         string $orderIdString
-    ): JsonResponse {
+    ): Response {
         Validator::make(
             array_merge(
                 ['orderId' => $orderIdString],
@@ -45,6 +45,6 @@ final class RemoveLineItemController extends Controller
             throw new BadRequestHttpException($exception->getMessage());
         }
 
-        return response()->json();
+        return response()->noContent();
     }
 }

--- a/docs/api.apib
+++ b/docs/api.apib
@@ -114,7 +114,7 @@ An existing line item can be deleted again from an order by issuing the followin
             "lineItemId": "8f712476-9d07-4642-89ef-2278972ae16d"
         }
 
-+ Response 200
++ Response 204
 
 ### Checkout order [POST /api/orders/{uuid}/checkout]
 
@@ -131,4 +131,4 @@ As of now, the order is immutable and hence no line items can be added or remove
             "emailAddress": "me@example.org"
         }
 
-+ Response 200
++ Response 204

--- a/tests/Feature/App/Http/Controllers/Orders/CheckoutControllerTest.php
+++ b/tests/Feature/App/Http/Controllers/Orders/CheckoutControllerTest.php
@@ -41,7 +41,7 @@ final class CheckoutControllerTest extends TestCase
             }
         );
 
-        $response->assertStatus(Response::HTTP_OK);
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
     }
 
     /**

--- a/tests/Feature/App/Http/Controllers/Orders/RemoveLineItemControllerTest.php
+++ b/tests/Feature/App/Http/Controllers/Orders/RemoveLineItemControllerTest.php
@@ -39,7 +39,7 @@ final class RemoveLineItemControllerTest extends TestCase
             }
         );
 
-        $response->assertStatus(Response::HTTP_OK);
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
     }
 
     /**


### PR DESCRIPTION
Streamline responses from API endpoints without response data to return a HTTP 204 status without the weird empty JSON array.