### PR TITLE
Add static code analysis using PHPStan (level 0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build up logs down restart composer artisan lint lint-fix tests
+.PHONY: build up logs down restart composer artisan lint lint-fix analyse tests
 
 user := $(shell id -u):$(shell id -g)
 
@@ -35,6 +35,9 @@ lint:
 
 lint-fix:
 	docker-compose exec php vendor/bin/php-cs-fixer fix --verbose
+
+analyse:
+	docker-compose exec php vendor/bin/phpstan analyse
 
 tests:
 	docker-compose exec php vendor/bin/phpunit $(filter-out $@,$(MAKECMDGOALS))

--- a/app/ValueObjects/UuidIdentifier.php
+++ b/app/ValueObjects/UuidIdentifier.php
@@ -11,7 +11,7 @@ abstract class UuidIdentifier
      */
     private $uuid;
 
-    public function __construct(Uuid $uuid)
+    final public function __construct(Uuid $uuid)
     {
         $this->uuid = $uuid;
     }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^3.0",
+        "phpstan/phpstan": "^0.12.25",
         "phpunit/phpunit": "^8.0"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "711bfc2306f2e578f7f4c0f2a31f3511",
+    "content-hash": "5c08c4b851613c7cd49826ba086e87c7",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -4588,6 +4588,48 @@
                 "stub"
             ],
             "time": "2020-01-20T15:57:02+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "0.12.25",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "9619551d68b2d4c0d681a8df73f3c847c798ee64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9619551d68b2d4c0d681a8df73f3c847c798ee64",
+                "reference": "9619551d68b2d4c0d681a8df73f3c847c798ee64",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "time": "2020-05-10T20:36:16+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,6 @@
+parameters:
+	level: 0
+	paths:
+		- app
+		- domain
+		- tests


### PR DESCRIPTION
Perform static analysis using `make analyse` and PHPStan. `app/`, `domain/` and `tests/` are checked on level 0 errors.